### PR TITLE
Usage of systolic instead of diastolic

### DIFF
--- a/docs/AQL/master02-overview.adoc
+++ b/docs/AQL/master02-overview.adoc
@@ -33,7 +33,7 @@ Below is an example of AQL statement. This statement returns all blood pressure 
 ----
 SELECT                                                          -- Select clause
     o/data[at0001]/.../items[at0004]/value AS systolic,         -- Identified path with named result
-    o/data[at0001]/.../items[at0005]/value AS systolic,
+    o/data[at0001]/.../items[at0005]/value AS diastolic,
 FROM                                                            -- From clause
     EHR[ehr_id=$ehrId]                                          -- RM class expression
         CONTAINS                                                -- containment


### PR DESCRIPTION
The structure example (2.3) uses the term systolic twice in the select clause.
Diastolic is the correct term for "at0005" as described in the text.