### PR TITLE
SPECQUERY-3: adding support for constants inside column expression

### DIFF
--- a/docs/AQL/master00-amendment_record.adoc
+++ b/docs/AQL/master00-amendment_record.adoc
@@ -12,6 +12,12 @@
 |[[latest_issue_date]]12 Dec 2020
 
 |
+|{spec_tickets}/SPECQUERY-3[SPECQUERY-3^] Add support for constants (fixed values) in column expression.
+|D Bosca, +
+ S Iancu
+|12 Dec 2020
+
+|
 |{spec_tickets}/SPECQUERY-7[SPECQUERY-7^] Add support for NOT CONTAINS.
 |T Beale, +
  S Iancu

--- a/docs/AQL/master03-syntax.adoc
+++ b/docs/AQL/master03-syntax.adoc
@@ -21,6 +21,7 @@ Keywords in AQL are not case sensitive, so `SELECT`, `Select`, `select`, `SeLeCt
 * `AND`, `OR`, `NOT`
 * functions: `count`, `min`, `max`, `sum`, `avg`, `terminology`, `now`, `current-date`, `current-date-time`
 * `LIKE`, `matches`, `in`, `exists`, `not in`
+* constants: true, false
 * `"` and `'`: double and single quote characters are used to delimit string values;
 * `|`: bar characters are used to delimit intervals;
 * `[]`: brackets are used to delimit coded terms, archetype id values or openEHR reference model class attribute values.
@@ -808,7 +809,8 @@ A `SELECT` clause specifies what data is to be retrieved by the AQL query. The d
 ==== Syntax
 The syntax always starts with the keyword `SELECT`, optionally followed by `TOP` (deprecated - see <<TOP, below>>), followed by one or more _column expressions_.
 
-A column expression is formed by an <<_aql_identified_paths,identified path>>, a <<_functions,function>> or plain <<_aql_variables,variable>> name defined in the `FROM` clause.
+A column expression is formed by an <<_aql_identified_paths,identified path>>, a <<_functions,function>>, a constant value or plain <<_aql_variables,variable>> name defined in the `FROM` clause.
+A constant is a primitive type value (see <<_built_in_types>>), where strings, dates, times and datetimes should be quoted, numbers and booleans are not quoted.
 Where a variable name is specified, the full object of the type associated with the variable is retrieved, such as a `COMPOSITION`, `OBSERVATION` etc.
 Where a function is specified, the call has to be done using the specified arguments and the results are returned.
 Where an identified path is specified, the data item(s) having that archetype path are returned.
@@ -832,6 +834,19 @@ FROM
 SELECT c
 FROM EHR e[ehr_id/value=$ehrUid] 
     CONTAINS COMPOSITION c
+--------
+
+.Example 3: Use of constants and function as column expressions.
+--------
+SELECT
+    true AS dangerousBP, "alert" as indication, count(*) as counter
+FROM
+    EHR [ehr_id/value=$ehrUid]
+        CONTAINS COMPOSITION [openEHR-EHR-COMPOSITION.encounter.v1]
+            CONTAINS OBSERVATION obs [openEHR-EHR-OBSERVATION.blood_pressure.v1]
+WHERE
+    obs/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude>= 160 OR
+    obs/data[at0001]/events[at0006]/data[at0003]/items[at0005]/value/magnitude>= 110
 --------
 
 ==== TOP


### PR DESCRIPTION
Changed definition of SELECT clause column expression to support also constants.

Grammar changes will be made in https://github.com/openEHR/specifications-QUERY/tree/SPECQUERY-30_antlr4_grammar